### PR TITLE
Move enum instances to its companion object

### DIFF
--- a/helios-core/src/test/kotlin/helios/instances/EnumTest.kt
+++ b/helios-core/src/test/kotlin/helios/instances/EnumTest.kt
@@ -5,31 +5,31 @@ import helios.core.EnumValueNotFound
 import helios.core.JsInt
 import helios.core.JsString
 import helios.core.StringDecodingError
-import io.kotlintest.assertions.arrow.either.beLeft
-import io.kotlintest.assertions.arrow.either.beRight
-import io.kotlintest.should
+import io.kotlintest.assertions.arrow.either.shouldBeLeft
+import io.kotlintest.assertions.arrow.either.shouldBeRight
 
 private enum class Foo {
-    A
+  A
 }
 
 internal class EnumTest : UnitSpec() {
+  init {
 
-    init {
-        "Enums should be encoded and decoded successfully" {
-            val encoded = with(EnumEncoderInstance<Foo>()) { Foo.A.encode() }
-            val decoded = encoded.decode(EnumDecoderInstance<Foo>())
-            decoded should beRight(Foo.A)
-        }
-
-        "invalid enum value produces the correct error" {
-            val decoded = EnumDecoderInstance<Foo>().decode(JsString("B"))
-            decoded should beLeft(EnumValueNotFound(JsString("B")))
-        }
-
-        "invalid json produces the correct error" {
-            val decoded = EnumDecoderInstance<Foo>().decode(JsInt(1))
-            decoded should beLeft(StringDecodingError(JsInt(1)))
-        }
+    "Enums should be encoded and decoded successfully" {
+      Enum.Companion.decoder<Foo>().decode(Enum.Companion.encoder<Foo>().run {
+        Foo.A.encode()
+      }).shouldBeRight(Foo.A)
     }
+
+    "invalid enum value produces the correct error" {
+      val decoded = Enum.Companion.decoder<Foo>().decode(JsString("B"))
+      decoded.shouldBeLeft(EnumValueNotFound(JsString("B")))
+    }
+
+    "invalid json produces the correct error" {
+      val decoded = Enum.Companion.decoder<Foo>().decode(JsInt(1))
+      decoded.shouldBeLeft(StringDecodingError(JsInt(1)))
+    }
+
+  }
 }


### PR DESCRIPTION
As `Enum` on kotlin has a companion object we can use the `function` format to create the instances instead of the `interface` way